### PR TITLE
Added missing slash in docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -45,7 +45,7 @@
                     "scripting_v2/**.yml",
                     "scripting_v3/**.yml",
                     "scripting_v2/api/**.yml",
-                    "scripting_v3/api**.yml"
+                    "scripting_v3/api/**.yml"
                 ]
             }
         ],


### PR DESCRIPTION
Added a missing slash in scripting_v3/api/**.yml which might be causing redirects to /scripting_v2 version of the namespaces when the Scripting V3 tab is selected on the website. I'm not sure if this is the root cause, because I got errors relating to build files when building the documentation using docfx.